### PR TITLE
Re-add #![feature(impl_trait_projections)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(not(test), no_std)]
-#![allow(unknown_lints, async_fn_in_trait)]
-#![allow(stable_features)]
+#![feature(impl_trait_projections)]
 #![feature(async_fn_in_trait)]
+#![allow(stable_features, unknown_lints, async_fn_in_trait)]
 
 #[cfg(feature = "async")]
 pub mod asynch;


### PR DESCRIPTION
This should allow older nightly (and Xtensa) users to use buffered-io.